### PR TITLE
feat(options): allow changing `rendered` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ export class DemoComponent {
     constructor() {
         this.lottieConfig = {
             path: 'assets/pinjump.json',
+            renderer: 'canvas',
             autoplay: true,
             loop: true
         };

--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -25,7 +25,7 @@ export class LottieAnimationViewComponent implements OnInit {
     ngOnInit() {
         this._options = {
             container: this.lavContainer.nativeElement,
-            renderer: 'svg',
+            renderer: this.options.renderer || 'svg',
             loop: this.options.loop !== false,
             autoplay: this.options.autoplay !== false,
             autoloadSegments: this.options.autoloadSegments !== false,


### PR DESCRIPTION
Lottie's `rendered` option was hardcoded to `svg`, this allows the option to be updated, keeping `svg` as a default.

I have a use case where `svg` renders a glitch, but `canvas` works fine.

I've also added `dist` to the repository, so that installing the package directly from GitHub works.